### PR TITLE
[003] Primary and Text Buttons

### DIFF
--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/buttons/PrimaryButton.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/buttons/PrimaryButton.kt
@@ -1,0 +1,39 @@
+package com.icdominguez.smartstep.presentation.composables.buttons
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.icdominguez.smartstep.presentation.designsystem.LocalSmartStepTypography
+import com.icdominguez.smartstep.presentation.designsystem.SmartStepTheme
+
+@Composable
+fun PrimaryButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Button(
+        modifier = modifier,
+        onClick = { onClick() },
+        shape = RoundedCornerShape(10.dp),
+        enabled = enabled,
+    ) {
+        Text(
+            text = text,
+            style = LocalSmartStepTypography.current.bodyLargeMedium
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PrimaryButtonPreview() {
+    SmartStepTheme {
+        PrimaryButton(text = "Button") {}
+    }
+}

--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/buttons/TextButton.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/buttons/TextButton.kt
@@ -1,0 +1,36 @@
+package com.icdominguez.smartstep.presentation.composables.buttons
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.icdominguez.smartstep.presentation.designsystem.LocalSmartStepTypography
+import com.icdominguez.smartstep.presentation.designsystem.SmartStepTheme
+
+@Composable
+fun TextButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    TextButton(
+        modifier = modifier,
+        onClick = { onClick() },
+        enabled = enabled,
+    ) {
+        Text(
+            text = text,
+            style = LocalSmartStepTypography.current.bodyLargeMedium,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TextButtonPreview() {
+    SmartStepTheme {
+        TextButton(text = "Exit") {}
+    }
+}


### PR DESCRIPTION
This commit creates ``Primary`` and ``Text`` Buttons as described in Figma.

<img width="338" height="48" alt="Screenshot 2026-02-10 at 10 17 55" src="https://github.com/user-attachments/assets/44c46807-e414-437b-9c6e-a9f7dceae0bf" />
<img width="63" height="35" alt="Screenshot 2026-02-10 at 10 18 02" src="https://github.com/user-attachments/assets/2f4a54d9-9824-4971-89a8-eb008181e01e" />
