### PR TITLE
[005] Picker input and DropDownMenu

### DIFF
--- a/app/src/main/java/com/icdominguez/smartstep/presentation/MainActivity.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/MainActivity.kt
@@ -5,15 +5,23 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.icdominguez.smartstep.presentation.composables.DefaultScreen
+import com.icdominguez.smartstep.presentation.composables.SmartStepPickerInput
+import com.icdominguez.smartstep.presentation.composables.dropdown.SmartStepDropDownMenu
 import com.icdominguez.smartstep.presentation.composables.switcher.UnitSwitcher
 import com.icdominguez.smartstep.presentation.designsystem.LocalSmartStepTypography
 import com.icdominguez.smartstep.presentation.designsystem.SmartStepTheme
@@ -28,27 +36,55 @@ class MainActivity : ComponentActivity() {
             SmartStepTheme {
                 DefaultScreen(
                     content = {
-                        Column(
+                        val unitSwitcherOptionSelected = remember { mutableStateOf("kg") }
+                        val genderSelected = remember { mutableStateOf("Male") }
+
+                        Box(
                             modifier = Modifier
-                                .fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
+                                .fillMaxWidth()
+                                .padding(16.dp)
                         ) {
-                            Text(
-                                text = "Welcome to SmartStep 👟",
-                                style = LocalSmartStepTypography.current.bodyLargeRegular,
-                            )
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "Welcome to SmartStep 👟",
+                                    style = LocalSmartStepTypography.current.bodyLargeRegular,
+                                )
 
-                            val unitSwitcherOptionSelected = remember { mutableStateOf("kg") }
+                                UnitSwitcher(
+                                    leftOption = "kg",
+                                    rightOption = "lbs",
+                                    selectedOption = unitSwitcherOptionSelected.value,
+                                    onOptionSelected = {
+                                        unitSwitcherOptionSelected.value = it
+                                    }
+                                )
 
-                            UnitSwitcher(
-                                leftOption = "kg",
-                                rightOption = "lbs",
-                                selectedOption = unitSwitcherOptionSelected.value,
-                                onOptionSelected = {
-                                    unitSwitcherOptionSelected.value = it
-                                }
-                            )
+                                SmartStepDropDownMenu(
+                                    title = "Gender",
+                                    options = listOf("Male", "Female"),
+                                    selectedOption = genderSelected.value,
+                                    onOptionSelected = {
+                                        genderSelected.value = it
+                                    }
+                                )
+
+                                SmartStepPickerInput(
+                                    title = "Height",
+                                    selectedValue = "160 cm",
+                                )
+
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                SmartStepPickerInput(
+                                    title = "Weight",
+                                    selectedValue = "60 kg",
+                                )
+                            }
                         }
                     }
                 )

--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/SmartStepPickerInput.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/SmartStepPickerInput.kt
@@ -1,0 +1,87 @@
+package com.icdominguez.smartstep.presentation.composables
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.icdominguez.smartstep.presentation.designsystem.LocalSmartStepTypography
+import com.icdominguez.smartstep.presentation.designsystem.SmartStepTheme
+import com.icdominguez.smartstep.presentation.designsystem.StrokeMain
+import com.icdominguez.smartstep.presentation.designsystem.TextPrimary
+import com.icdominguez.smartstep.presentation.designsystem.TextSecondary
+
+@Composable
+fun SmartStepPickerInput(
+    modifier: Modifier = Modifier,
+    title: String,
+    selectedValue: String,
+    isExpanded: Boolean = false,
+) {
+    val roundedCornerShape = RoundedCornerShape(10.dp)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(
+                shape = roundedCornerShape
+            )
+            .border(
+                width = 1.dp,
+                color = StrokeMain,
+                shape = roundedCornerShape,
+            )
+            .padding(
+                vertical = 8.dp,
+                horizontal = 16.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column {
+            Text(
+                text = title,
+                style = LocalSmartStepTypography.current.bodySmallRegular,
+                color = TextSecondary,
+            )
+
+            Text(
+                text = selectedValue,
+                style = LocalSmartStepTypography.current.bodyLargeRegular,
+                color = TextPrimary,
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Icon(
+            imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+            tint = TextPrimary,
+            contentDescription = "Expand/Collapse",
+        )
+
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SmartStepInputPreview() {
+    SmartStepTheme {
+        SmartStepPickerInput(
+            title = "Gender",
+            selectedValue = "Male",
+        )
+    }
+}

--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/dropdown/SmartStepDropDownMenu.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/dropdown/SmartStepDropDownMenu.kt
@@ -1,0 +1,94 @@
+package com.icdominguez.smartstep.presentation.composables.dropdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.icdominguez.smartstep.presentation.composables.SmartStepPickerInput
+import com.icdominguez.smartstep.presentation.designsystem.BackgroundWhite
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SmartStepDropDownMenu(
+    modifier: Modifier = Modifier,
+    title: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = {
+            isExpanded = !isExpanded
+        },
+    ) {
+        Column(
+            modifier = Modifier.menuAnchor(
+                type = ExposedDropdownMenuAnchorType.PrimaryEditable,
+                enabled = true
+            ),
+        ) {
+            SmartStepPickerInput(
+                title = title,
+                selectedValue = selectedOption,
+                isExpanded = isExpanded,
+            )
+
+            Spacer(Modifier.height(8.dp))
+        }
+
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            shape = RoundedCornerShape(8.dp),
+            containerColor = BackgroundWhite,
+        ) {
+            Column(
+                modifier = modifier
+                    .background(
+                        color = BackgroundWhite,
+                        shape = MaterialTheme.shapes.medium
+                    )
+                    .padding(horizontal = 8.dp)
+            ) {
+                options.map { option ->
+                    SmartStepDropDownItem(
+                        text = option,
+                        isSelected = option == selectedOption,
+                        onClick = {
+                            onOptionSelected(option)
+                            isExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SmartStepDropDownMenuPreview() {
+    SmartStepDropDownMenu(
+        title = "Gender",
+        options = listOf("Male", "Female"),
+        selectedOption = "Male",
+        onOptionSelected = {}
+    )
+}

--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/dropdown/SmartStepDropdownMenuItem.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/dropdown/SmartStepDropdownMenuItem.kt
@@ -1,0 +1,100 @@
+package com.icdominguez.smartstep.presentation.composables.dropdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.icdominguez.smartstep.R
+import com.icdominguez.smartstep.presentation.designsystem.BackgroundSecondary
+import com.icdominguez.smartstep.presentation.designsystem.ButtonPrimary
+import com.icdominguez.smartstep.presentation.designsystem.LocalSmartStepTypography
+import com.icdominguez.smartstep.presentation.designsystem.SmartStepTheme
+import com.icdominguez.smartstep.presentation.designsystem.TextPrimary
+
+@Composable
+fun SmartStepDropDownItem(
+    text: String,
+    isSelected: Boolean = false,
+    onClick: (String) -> Unit
+) {
+    val roundedCornerShape = RoundedCornerShape(10.dp)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(roundedCornerShape)
+            .background(
+                color = if(isSelected) BackgroundSecondary else Color.Transparent,
+                shape = roundedCornerShape
+            )
+            .clickable(
+                onClick = { onClick(text) }
+            )
+            .padding(
+                vertical = 12.dp,
+                horizontal = 8.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = LocalSmartStepTypography.current.bodyLargeRegular,
+            color = TextPrimary,
+        )
+
+        if(isSelected) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                painter = painterResource(R.drawable.ic_selected),
+                modifier = Modifier
+                    .size(16.dp),
+                tint = ButtonPrimary,
+                contentDescription = "Check"
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SmartStepDropDownItemPreview() {
+    SmartStepTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier
+                .padding(
+                    vertical = 4.dp,
+                    horizontal = 6.dp,
+                )
+        ) {
+            SmartStepDropDownItem(
+                text = "Male",
+                isSelected = false,
+                onClick = {},
+            )
+
+            SmartStepDropDownItem(
+                text = "Female",
+                isSelected = true,
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/icdominguez/smartstep/presentation/composables/switcher/UnitSwitcher.kt
+++ b/app/src/main/java/com/icdominguez/smartstep/presentation/composables/switcher/UnitSwitcher.kt
@@ -2,11 +2,9 @@ package com.icdominguez.smartstep.presentation.composables.switcher
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun UnitSwitcher(
@@ -19,7 +17,6 @@ fun UnitSwitcher(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
     ) {
         SwitcherOption(
             modifier = Modifier


### PR DESCRIPTION
This commits adds this 3 composables to the design system:

- ``SmartStepPickerInput``: Allows user to open the dropdown menu or the picker dialog. Shows the title and the selected value.
- ``SmartStepDropDownMenuItem``: Selectable Items in the menu. Change its background and adds a tick icon if is selected.
- ``SmartStepDropDownMenu``: Contains all the SmartStepDropDownMenuItems and appears above the rest of the items in the scree. Uses ``ExpandedDropDwonMenuBox`` and ``ExpandedDropDownMenu`` to fit the with of the input.

https://github.com/user-attachments/assets/b13b3483-9674-4cb3-8c2d-45e8b1004c52
